### PR TITLE
Fixing the requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Labelit creates a [Label Studio](https://labelstud.io/) server for each project 
 4. Switch to conda env (recommended) : `conda activate label-studio`
 5. Install requirements for Labelit : `pip install -r requirements.txt`
 6. Enter Django app directory : `cd labelit`
-7. Set secret key for Django as Environment variable (You can generate secret key using https://gist.github.com/ndarville/3452907 or https://djecrety.ir): `export DJANGO_SECRET_KEY="<generated_key>"`
+7. Set secret key for Django as Environment variable (You can generate secret key using https://gist.github.com/ndarville/3452907 or https://djecrety.ir): `export DJANGO_SECRET_KEY='<generated_key>'`
 8. Perform database migration (By default, it uses local SQLite database. If you want to connect to another database, check Django documentation) : `python manage.py migrate`
 9. Create admin user : `python manage.py createsuperuser`
 10. Run the server using gunicorn : `gunicorn --worker-class=gevent --worker-connections=500 --workers=1 -b '0.0.0.0:8000' labelit.wsgi`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 django==3.0.7
 django-revproxy==0.10.0
 label-studio==0.6.0
-apscheduler==3.6.3
+apscheduler==3.7.0
 psutil==5.7.0
-django-crispy-forms=1.9.1
+django-crispy-forms==1.9.1
+label-studio-converter==0.0.17
+gunicorn==20.1.0
+gevent==21.8.0


### PR DESCRIPTION
This repo as of now only works with old versions of a few dependent libraries.
The `requirements.txt` has been updated to lock those versions in while a fix to upgrade this repo to the latest version of Label Studio is worked upon.